### PR TITLE
Fix Torcedor ativo validation

### DIFF
--- a/App/Models/Torcedor.php
+++ b/App/Models/Torcedor.php
@@ -28,18 +28,19 @@ class Torcedor extends Model {
 		$this->$atributo = $valor;
 	}
 
-	public function validar()
-    {
-		if (empty($this->nome) || empty($this->documento)
-            || empty($this->cep) || empty($this->endereco)
-            || empty($this->bairro) || empty($this->cidade)
-            || empty($this->uf) || empty($this->telefone)
-            || empty($this->email) || empty($this->ativo)) {
-				return false;
-			}
+       public function validar()
+   {
+               if (empty($this->nome) || empty($this->documento)
+           || empty($this->cep) || empty($this->endereco)
+           || empty($this->bairro) || empty($this->cidade)
+           || empty($this->uf) || empty($this->telefone)
+           || empty($this->email)
+           || !isset($this->ativo) || $this->ativo === '') {
+                               return false;
+                       }
 
-		return true;
-	}
+               return true;
+       }
 
 	public function salvar()
     {


### PR DESCRIPTION
## Summary
- treat `ativo` as set even if value is `0`
- reject blank or unset `ativo`

## Testing
- `php -l App/Models/Torcedor.php`

------
https://chatgpt.com/codex/tasks/task_e_687c4dfba28c832db30cf395b9bd45b1